### PR TITLE
fix empty screen issue for main activity after power off/on device

### DIFF
--- a/pws/app/src/main/kotlin/com/alelk/pws/pwapp/activity/MainActivity.kt
+++ b/pws/app/src/main/kotlin/com/alelk/pws/pwapp/activity/MainActivity.kt
@@ -88,6 +88,11 @@ open class MainActivity : AppCompatThemedActivity(), NavigationView.OnNavigation
     outState.putInt(KEY_NAVIGATION_ITEM_ID, mNavigationItemId)
   }
 
+  override fun onResume() {
+    super.onResume()
+    displayFragment()
+  }
+
   override fun onCreateOptionsMenu(menu: Menu): Boolean {
     menuInflater.inflate(R.menu.menu_main, menu)
     return true


### PR DESCRIPTION
ho to reproduce:
- go to favorites
<img width="294" alt="image" src="https://github.com/user-attachments/assets/7a616712-e826-4bf3-9572-bc59421725be">

- power off device
- power on device

result:
the screen is empty
<img width="295" alt="image" src="https://github.com/user-attachments/assets/47213b60-f527-404f-a43d-a4daf09cf904">
