### PR TITLE
feat(category): Add sorting functionality for tag songs list

### DIFF
--- a/app/src/main/kotlin/io/github/alelk/pws/android/app/activity/TagSongsActivity.kt
+++ b/app/src/main/kotlin/io/github/alelk/pws/android/app/activity/TagSongsActivity.kt
@@ -1,8 +1,12 @@
 package io.github.alelk.pws.android.app.activity
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import androidx.activity.viewModels
+import androidx.appcompat.view.menu.MenuBuilder
 import androidx.lifecycle.asLiveData
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -20,11 +24,22 @@ class TagSongsActivity : AppCompatThemedActivity() {
   private lateinit var songsInfoAdapter: SongsInfoAdapter
   private val tagsViewModel: TagsViewModel by viewModels()
 
+  // Add sorting state
+  private var sortOrder = SORT_BY_ADDED_DATE
+  private var isAscending = false
+  private val sharedPrefs by lazy {
+    getSharedPreferences("category_sort_prefs", Context.MODE_PRIVATE)
+  }
+
+  // Add tagId as class property
+  private lateinit var tagId: String
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_category_songs)
 
-    val tagId = checkNotNull(intent.getStringExtra(TAG_ID)) { "$TAG_ID required" }
+    // Initialize tagId
+    tagId = checkNotNull(intent.getStringExtra(TAG_ID)) { "$TAG_ID required" }
     val tagName = intent.getStringExtra(TAG_NAME) ?: ""
 
     title = "${getString(R.string.title_activity_category_songs)} $tagName"
@@ -36,8 +51,27 @@ class TagSongsActivity : AppCompatThemedActivity() {
       layoutManager = LinearLayoutManager(this@TagSongsActivity)
     }
 
+    // Load saved preferences
+    sortOrder = sharedPrefs.getInt(KEY_SORTED_BY, SORT_BY_ADDED_DATE)
+    isAscending = sharedPrefs.getBoolean(KEY_IS_ASCENDING, false)
+
     tagsViewModel.getTagSongs(TagId.parse(tagId)).asLiveData().observe(this) { songInfoList ->
-      songsInfoAdapter.swapData(songInfoList)
+      val sortedList = when (sortOrder) {
+        SORT_BY_NUMBER -> {
+          if (isAscending) songInfoList.sortedBy { it.songNumber.number }
+          else songInfoList.sortedByDescending { it.songNumber.number }
+        }
+        SORT_BY_NAME -> {
+          if (isAscending) songInfoList.sortedBy { it.song.name }
+          else songInfoList.sortedByDescending { it.song.name }
+        }
+        SORT_BY_ADDED_DATE -> {
+          if (isAscending) songInfoList.sortedBy { it.songNumberId }
+          else songInfoList.sortedByDescending { it.songNumberId }
+        }
+        else -> songInfoList
+      }
+      songsInfoAdapter.swapData(sortedList)
     }
   }
 
@@ -48,8 +82,103 @@ class TagSongsActivity : AppCompatThemedActivity() {
     startActivity(intentSongView)
   }
 
+  // Add menu handling
+  override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    menuInflater.inflate(R.menu.menu_category_sort, menu)
+    return true
+  }
+
+  override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+    (menu as? MenuBuilder)?.setOptionalIconsVisible(true)
+    updateSortMenuIcons(menu)
+    return super.onPrepareOptionsMenu(menu)
+  }
+
+  private fun updateSortMenuIcons(menu: Menu) {
+    listOf(
+      R.id.action_sort_by_number to SORT_BY_NUMBER,
+      R.id.action_sort_by_name to SORT_BY_NAME,
+      R.id.action_sort_by_added_date to SORT_BY_ADDED_DATE
+    ).forEach { (menuId, sortType) ->
+      updateMenuIcon(menu.findItem(menuId), sortType)
+    }
+  }
+
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    return when (item.itemId) {
+      R.id.action_sort_by_number -> {
+        updateSortAndRefresh(SORT_BY_NUMBER, true)
+        true
+      }
+      R.id.action_sort_by_name -> {
+        updateSortAndRefresh(SORT_BY_NAME, true)
+        true
+      }
+      R.id.action_sort_by_added_date -> {
+        updateSortAndRefresh(SORT_BY_ADDED_DATE, false)
+        true
+      }
+      else -> super.onOptionsItemSelected(item)
+    }
+  }
+
+  // Add sorting logic
+  private fun updateSortAndRefresh(newSortOrder: Int, defaultAscending: Boolean) {
+    if (sortOrder == newSortOrder) {
+      isAscending = !isAscending
+    } else {
+      sortOrder = newSortOrder
+      isAscending = defaultAscending
+    }
+    saveSortPreferences()
+    refreshSongs()
+    invalidateOptionsMenu()
+  }
+
+  private fun saveSortPreferences() {
+    sharedPrefs.edit().apply {
+      putInt(KEY_SORTED_BY, sortOrder)
+      putBoolean(KEY_IS_ASCENDING, isAscending)
+      apply()
+    }
+  }
+
+  private fun refreshSongs() {
+    tagsViewModel.getTagSongs(TagId.parse(tagId)).asLiveData().observe(this) { songs ->
+      songsInfoAdapter.swapData(sortSongsList(songs))
+    }
+  }
+
+  private fun sortSongsList(songs: List<SongNumberWithSongWithBookWithFavorite>) = when (sortOrder) {
+    SORT_BY_NUMBER -> songs.sortedByDirection { it.songNumber.number }
+    SORT_BY_NAME -> songs.sortedByDirection { it.song.name }
+    SORT_BY_ADDED_DATE -> songs.sortedByDirection { it.songNumberId }
+    else -> songs
+  }
+
+  private inline fun <T : Comparable<T>> List<SongNumberWithSongWithBookWithFavorite>.sortedByDirection(
+    crossinline selector: (SongNumberWithSongWithBookWithFavorite) -> T
+  ) = if (isAscending) sortedBy(selector) else sortedByDescending(selector)
+
+  private fun updateMenuIcon(menuItem: MenuItem?, sortType: Int) {
+    menuItem?.let { item ->
+      if (sortOrder == sortType) {
+        val iconRes = if (isAscending) R.drawable.ic_arrow_upward else R.drawable.ic_arrow_downward
+        item.setIcon(iconRes)
+      } else {
+        item.icon = null
+      }
+    }
+  }
+
   companion object {
     const val TAG_NAME = "tag_name"
     const val TAG_ID = "tag_id"
+    // Add sorting constants
+    const val SORT_BY_ADDED_DATE = 2
+    const val SORT_BY_NUMBER = 3
+    const val SORT_BY_NAME = 4
+    private const val KEY_SORTED_BY = "category-sorted-by"
+    private const val KEY_IS_ASCENDING = "category-is-ascending"
   }
 }

--- a/app/src/main/res/menu/menu_category_sort.xml
+++ b/app/src/main/res/menu/menu_category_sort.xml
@@ -1,0 +1,15 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_sort_by_added_date"
+        android:title="@string/sort_by_added_date"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_sort_by_number"
+        android:title="@string/sort_by_number"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_sort_by_name"
+        android:title="@string/sort_by_name"
+        app:showAsAction="never" />
+</menu> 


### PR DESCRIPTION
- Implement sorting options for tag songs by added date, number, and name
- Add menu with sorting options and directional icons
- Persist sort preferences using SharedPreferences
- Support ascending and descending sort orders

<img width="452" alt="image" src="https://github.com/user-attachments/assets/db7f1827-2f5e-466a-97f7-8d3c79dd3e2d" />
<img width="474" alt="image" src="https://github.com/user-attachments/assets/80fe6af7-7d71-4753-8d13-9a2c9210785c" />
