### PR TITLE
Song: Text Size: fix crashing

### DIFF
--- a/app/src/main/kotlin/io/github/alelk/pws/android/app/dialog/SongPreferencesDialogFragment.kt
+++ b/app/src/main/kotlin/io/github/alelk/pws/android/app/dialog/SongPreferencesDialogFragment.kt
@@ -30,12 +30,14 @@ import io.github.alelk.pws.android.app.model.AppPreferencesViewModel
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import dagger.hilt.android.AndroidEntryPoint
 
 /**
  * Song Preferences Dialog Fragment
  *
  * Created by Alex Elkin on 26.12.2016.
  */
+@AndroidEntryPoint
 class SongPreferencesDialogFragment : DialogFragment() {
   private val viewModel: AppPreferencesViewModel by viewModels()
 


### PR DESCRIPTION
Описание проблемы:
При выборе песни и последующем переключении на раздел "text size" приложение падает. Крэш происходит из-за того, что при создании AppPreferencesViewModel, который использует Hilt для инъекций (через конструктор с параметром DataStore), используется дефолтный ViewModelProvider, ожидающий конструктор без параметров. Это приводит к NoSuchMethodException, так как конструктора по умолчанию нет.
Как воспроизвести:
1. Запустить приложение.
Выбрать любую песню.
3. Перейти на раздел "text size" (например, в диалоге настроек песни).
Приложение вылетает с ошибкой создания AppPreferencesViewModel.